### PR TITLE
Renzhi fix

### DIFF
--- a/lib/resty/awsauth/aws_authenticator.lua
+++ b/lib/resty/awsauth/aws_authenticator.lua
@@ -317,7 +317,10 @@ local function check_credential_date(ts_now, credential_date)
     end
 
     if ts_now > date_ts + credential_validate_time_length then
-        return nil, 'InvalidArgument', 'the credential has expired'
+        return nil, 'InvalidArgument', string.format(
+                'the credential has expired, credential_date: %s, ' ..
+                'credential_date_ts: %f, ts_now: %f',
+                credential_date, date_ts, ts_now)
     end
 
     return nil, nil, nil
@@ -344,8 +347,11 @@ local function authenticate_v4(ctx)
     if ctx.query_auth == false then
         if request_ts < ts_now - date_difference_tolerance or
                request_ts > ts_now + date_difference_tolerance then
-            return nil, 'RequestTimeTooSkewed', 'the difference between the '..
-                    'request time and the server time is to large'
+            return nil, 'RequestTimeTooSkewed', string.format(
+                    'the difference between the request time and the '..
+                    'server time is to large, request_date: %s, '..
+                    'request_date_ts: %f, ts_now: %f',
+                    date_info.request_date, date_info.request_ts, ts_now)
         end
     else
         local expires_ts = tonumber(ctx.expires)
@@ -354,7 +360,11 @@ local function authenticate_v4(ctx)
                     tostring(ctx.expires)
         end
         if ts_now > request_ts + expires_ts then
-            return nil, 'ExpiredToken', 'the token has expired'
+            return nil, 'ExpiredToken', string.format(
+                    'the token has expired, request_date: %s, '..
+                    'request_date_ts: %f, expires_ts: %f, ts_now: %f',
+                    date_info.request_date, date_info.request_ts,
+                    expires_ts, ts_now)
         end
     end
 
@@ -414,7 +424,9 @@ local function authenticate_v2(ctx)
                     .. tostring(ctx.expires)
         end
         if ts < ts_now then
-            return nil, 'ExpiredToken', 'the token has expired'
+            return nil, 'ExpiredToken', string.format(
+                    'the token has expired, expires: %f, ts_now: %f',
+                    ts, ts_now)
         end
         ctx.date = ctx.expires
     else
@@ -430,8 +442,11 @@ local function authenticate_v2(ctx)
 
         if ts < ts_now - date_difference_tolerance or
                   ts > ts_now + date_difference_tolerance then
-            return nil, 'RequestTimeTooSkewed', 'the difference between '..
-                    'the request time and the server time is too large'
+            return nil, 'RequestTimeTooSkewed', string.format(
+                    'the difference between the request time and the '..
+                    'server time is to large, request_date: %s, '..
+                    'request_date_ts: %f, ts_now: %f',
+                    date, ts, ts_now)
         end
 
         if ctx.headers['x-amz-date'] ~= nil then

--- a/lib/resty/awsauth/aws_authenticator.lua
+++ b/lib/resty/awsauth/aws_authenticator.lua
@@ -328,12 +328,8 @@ end
 
 
 local function authenticate_v4(ctx)
-    if ctx.service == 's3' and ctx.query_auth == true then
-        ctx.hashed_payload = signature_basic.unsigned_payload
-    else
-        ctx.hashed_payload = ctx.headers['x-amz-content-sha256'] or
-                signature_basic.empty_payload_hash
-    end
+    ctx.hashed_payload = ctx.headers['x-amz-content-sha256'] or
+            signature_basic.unsigned_payload
 
     local date_info,  err, msg = get_date_info(ctx)
     if err ~= nil then

--- a/lib/resty/awsauth/aws_signer.md
+++ b/lib/resty/awsauth/aws_signer.md
@@ -182,7 +182,8 @@ This method accepts the following arguments:
  - `query_auth` if set to `true`, the signature will be add to query string, otherwise the signature will
     be contained in 'Authorization' header.
 
- - `sign_payload` if set to `true`, the 'X-Amz-Content-SHA256' header will be add to the signing process.
+ - `sign_payload` if set to `true`, the SHA256 of the body will be calculated if header 'X-Amz-Content-SHA256'
+    is not specifed in `headers`.
 
  - `headers_not_to_sign` is a list of header names indicate which headers are not need to be signed.
 

--- a/t/authenticator.t
+++ b/t/authenticator.t
@@ -75,8 +75,8 @@ __DATA__
 GET /t
 --- response_body_like
 /
-AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=[0-9a-f]{64}
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}
+UNSIGNED-PAYLOAD
 [0-9]{8}T[0-9]{6}Z
 ziw5dp1alvty9n47qksu
 --- no_error_log
@@ -142,7 +142,7 @@ ziw5dp1alvty9n47qksu
 GET /t
 --- response_body_like
 /aaa/bbb\?foo=bar
-AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=[0-9a-f]{64}
+AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}
 ziw5dp1alvty9n47qksu
 --- no_error_log
 [error]
@@ -209,7 +209,7 @@ ziw5dp1alvty9n47qksu
 GET /t
 --- response_body_like
 /\?foo3&foo1=bar1&foo2=bar2
-AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=[0-9a-f]{64}
+AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}
 ziw5dp1alvty9n47qksu
 --- no_error_log
 [error]
@@ -272,8 +272,8 @@ ziw5dp1alvty9n47qksu
 GET /t
 --- response_body_like
 /
-AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=[0-9a-f]{64}
-fdcf4254fc02e5e41e545599f0be4f9f65e8be431ebc1fd301a96ea88dd0d5d6
+AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}
+UNSIGNED-PAYLOAD
 ziw5dp1alvty9n47qksu
 --- no_error_log
 [error]

--- a/t/authenticator.t
+++ b/t/authenticator.t
@@ -455,7 +455,223 @@ ziw5dp1alvty9n47qksu
     }
 --- request
 GET /t
---- response_body
-the credential has expired
+--- response_body_like chomp
+the credential has expired, credential_date: [0-9.]+, credential_date_ts: [0-9.]+, ts_now: [0-9.]+
+--- no_error_log
+[error]
+
+
+=== TEST 8: test request time too skewed
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        rewrite_by_lua '
+            local aws_signer = require("resty.awsauth.aws_signer")
+            local aws_authenticator = require("resty.awsauth.aws_authenticator")
+
+            local access_key = "ziw5dp1alvty9n47qksu"
+            local secret_key = "V+ZTZ5u5wNvXb+KP5g0dMNzhMeWe372/yRKx4hZV"
+            local signer, err, msg = aws_signer.new(access_key, secret_key)
+            if err ~= nil then
+                ngx.log(ngx.ERR, "failed to new a aws_signer" .. err .. " " .. msg)
+            end
+
+            local request = {
+                verb = "GET",
+                uri = "/",
+                headers = {
+                    Host = "127.0.0.1",
+                },
+            }
+
+            local ctx, err, msg = signer:add_auth_v4(request)
+            if err ~= nil then
+                ngx.log(ngx.ERR, "failed to add auth: " .. err .. " " .. msg)
+            end
+
+            request.headers["X-Amz-Date"] = "20150101T000000Z"
+
+            local function get_secret_key(secret_key_in_request)
+                return secret_key
+            end
+            local function get_bucket_from_host(host)
+                return nil
+            end
+            local authenticator = aws_authenticator.new(get_secret_key, get_bucket_from_host)
+
+            local low_headers = {}
+            for k, v in pairs(request.headers) do
+                low_headers[k:lower()] = v
+            end
+            request.headers = low_headers
+            local ctx, err, msg = authenticator:authenticate(request)
+            ngx.say(msg)
+        ';
+    }
+--- request
+GET /t
+--- response_body_like chomp
+the difference between the request time and the server time is to large, request_date: 20150101T000000Z, request_date_ts: 1420070400.000000, ts_now: [0-9.]+
+--- no_error_log
+[error]
+
+
+=== TEST 9: test token expired
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        rewrite_by_lua '
+            local aws_signer = require("resty.awsauth.aws_signer")
+            local aws_authenticator = require("resty.awsauth.aws_authenticator")
+
+            local access_key = "ziw5dp1alvty9n47qksu"
+            local secret_key = "V+ZTZ5u5wNvXb+KP5g0dMNzhMeWe372/yRKx4hZV"
+            local signer, err, msg = aws_signer.new(access_key, secret_key)
+            if err ~= nil then
+                ngx.log(ngx.ERR, "failed to new a aws_signer" .. err .. " " .. msg)
+            end
+
+            local request = {
+                verb = "GET",
+                uri = "/",
+                args = {
+                    ["X-Amz-Date"] = "20170522T054624Z",
+                    ["X-Amz-Expires"] = "1",
+                    ["X-Amz-Algorithm"] = "AWS4-HMAC-SHA256",
+                    ["X-Amz-Credential"] = "ziw5dp1alvty9n47qksu/20170522/us-east-1/s3/aws4_request",
+                    ["X-Amz-Signature"] = "0d4643d94b9df131100d5ac320bb0d2a73255820f166789feb",
+                    ["X-Amz-SignedHeaders"] = "host",
+                },
+                headers = {
+                    Host = "127.0.0.1",
+                },
+            }
+
+            local function get_secret_key(secret_key_in_request)
+                return secret_key
+            end
+            local function get_bucket_from_host(host)
+                return nil
+            end
+
+            local authenticator = aws_authenticator.new(get_secret_key, get_bucket_from_host)
+
+            local low_headers = {}
+            for k, v in pairs(request.headers) do
+                low_headers[k:lower()] = v
+            end
+            request.headers = low_headers
+            local ctx, err, msg = authenticator:authenticate(request)
+            ngx.say(msg)
+        ';
+    }
+--- request
+GET /t
+--- response_body_like chomp
+the token has expired, request_date: 20170522T054624Z, request_date_ts: 1495431984.000000, expires_ts: 1.000000, ts_now: [0-9.]+
+--- no_error_log
+[error]
+
+
+=== TEST 10: test token expired v2
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        rewrite_by_lua '
+            local aws_signer = require("resty.awsauth.aws_signer")
+            local aws_authenticator = require("resty.awsauth.aws_authenticator")
+
+            local access_key = "ziw5dp1alvty9n47qksu"
+            local secret_key = "V+ZTZ5u5wNvXb+KP5g0dMNzhMeWe372/yRKx4hZV"
+            local signer, err, msg = aws_signer.new(access_key, secret_key)
+            if err ~= nil then
+                ngx.log(ngx.ERR, "failed to new a aws_signer" .. err .. " " .. msg)
+            end
+
+            local request = {
+                verb = "GET",
+                uri = "/",
+                args = {
+                    ["Expires"] = "1234",
+                    ["AWSAccessKeyId"] = "ziw5dp1alvty9n47qksu",
+                    ["Signature"] = "ijfiewjafiwejfi",
+                },
+                headers = {
+                    Host = "127.0.0.1",
+                },
+            }
+
+            local function get_secret_key(secret_key_in_request)
+                return secret_key
+            end
+            local function get_bucket_from_host(host)
+                return nil
+            end
+
+            local authenticator = aws_authenticator.new(get_secret_key, get_bucket_from_host)
+
+            local low_headers = {}
+            for k, v in pairs(request.headers) do
+                low_headers[k:lower()] = v
+            end
+            request.headers = low_headers
+            local ctx, err, msg = authenticator:authenticate(request)
+            ngx.say(msg)
+        ';
+    }
+--- request
+GET /t
+--- response_body_like chomp
+the token has expired, expires: 1234.000000, ts_now: [0-9.]+
+--- no_error_log
+[error]
+
+
+=== TEST 11: test request time too skewed v2
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        rewrite_by_lua '
+            local aws_signer = require("resty.awsauth.aws_signer")
+            local aws_authenticator = require("resty.awsauth.aws_authenticator")
+
+            local access_key = "ziw5dp1alvty9n47qksu"
+            local secret_key = "V+ZTZ5u5wNvXb+KP5g0dMNzhMeWe372/yRKx4hZV"
+            local signer, err, msg = aws_signer.new(access_key, secret_key)
+            if err ~= nil then
+                ngx.log(ngx.ERR, "failed to new a aws_signer" .. err .. " " .. msg)
+            end
+
+            local request = {
+                verb = "GET",
+                uri = "/",
+                headers = {
+                    Host = "127.0.0.1",
+                    Authorization = "AWS ziw5dp1alvty9n47qksu:ijfeiawif",
+                    Date = "Tue, 27 Mar 2007 19:36:42 +0000",
+                },
+            }
+
+            local function get_secret_key(secret_key_in_request)
+                return secret_key
+            end
+            local function get_bucket_from_host(host)
+                return nil
+            end
+            local authenticator = aws_authenticator.new(get_secret_key, get_bucket_from_host)
+
+            local low_headers = {}
+            for k, v in pairs(request.headers) do
+                low_headers[k:lower()] = v
+            end
+            request.headers = low_headers
+            local ctx, err, msg = authenticator:authenticate(request)
+            ngx.say(msg)
+        ';
+    }
+--- request
+GET /t
+--- response_body_like chomp
+the difference between the request time and the server time is to large, request_date: Tue, 27 Mar 2007 19:36:42 \+0000, request_date_ts: 1175024202.000000, ts_now: [0-9.]+
 --- no_error_log
 [error]

--- a/t/signer.t
+++ b/t/signer.t
@@ -53,8 +53,8 @@ __DATA__
 GET /t
 --- response_body_like
 /
-AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=[0-9a-f]{64}
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}
+UNSIGNED-PAYLOAD
 [0-9]{8}T[0-9]{6}Z
 --- no_error_log
 [error]
@@ -139,7 +139,7 @@ nil
 GET /t
 --- response_body_like
 /aaa/bbb\?foo=bar
-AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=[0-9a-f]{64}
+AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}
 --- no_error_log
 [error]
 
@@ -184,7 +184,7 @@ AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_requ
 GET /t
 --- response_body_like
 /\?foo3&foo1=bar1&foo2=bar2
-AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=[0-9a-f]{64}
+AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}
 --- no_error_log
 [error]
 
@@ -226,8 +226,8 @@ AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_requ
 GET /t
 --- response_body_like
 /
-AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=[0-9a-f]{64}
-fdcf4254fc02e5e41e545599f0be4f9f65e8be431ebc1fd301a96ea88dd0d5d6
+AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}
+UNSIGNED-PAYLOAD
 --- no_error_log
 [error]
 

--- a/t/signer.t
+++ b/t/signer.t
@@ -1,10 +1,8 @@
 # vi:ft=
 
-use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua 'no_plan';
 
 repeat_each(2);
-
-plan tests => repeat_each() * (3 * blocks());
 
 our $HttpConfig = <<'_EOC_';
     #lua_code_cache off;
@@ -98,7 +96,7 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 --- request
 GET /t
 --- response_body_like
-/?X-Amz-Date=[0-9]{8}T[[0-9]{6}Z&X-Amz-Credential=ziw5dp1alvty9n47qksu%2F[0-9]{8}%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=60&X-Amz-Signature=[0-9a-f]{64}
+/?X-Amz-Signature=[0-9a-f]{64}
 nil
 nil
 nil
@@ -357,7 +355,7 @@ AWS4-HMAC-SHA256 Credential=ziw5dp1alvty9n47qksu/[0-9]{8}/us-east-1/s3/aws4_requ
 --- request
 GET /t
 --- response_body_like
-/?X-Amz-Date=[0-9]{8}T[[0-9]{6}Z&X-Amz-Credential=ziw5dp1alvty9n47qksu%2F[0-9]{8}%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=1234&X-Amz-Signature=[0-9a-f]{64}
+/?X-Amz-Signature=[0-9a-f]{64}
 nil
 nil
 nil


### PR DESCRIPTION
1，修复当service不是s3时，缺少x-amz-conttent-sha256头的问题
2，改变参数sign_payload的含义，当sign_payload为false时，原来的含义是：不将x-amz-content-sha256包含到signed_headers中，程序仍然可能会计算body的sha256，并添加该头。现在的含义是：不计算body的sha256，将x-amz-content-sha256设置为UNSIGNED-PAYLOAD，并包含到signed_headers中
3，修复单元测试中因字典字段顺序改变造成测试通不过的问题
4，添加详细的错误日志